### PR TITLE
Open all selected files instead of just the first

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,12 @@ plugin_vis_nnn.nnn_args = "-RuA"
 vis.events.subscribe(vis.events.INIT, function()
     vis:map(vis.modes.NORMAL, " n", ":nnn<Enter>", "run nnn filemanager in current dir")
 end)
+
+-- Get a list of files with exported nnn() function
+local myfunc = function()
+	local files = plugin_vis_nnn.nnn()
+	for _, file in pairs(files) do
+		-- do something with file
+	end
+end
 ```

--- a/init.lua
+++ b/init.lua
@@ -28,9 +28,12 @@ end
 vis:command_register("nnn", function(argv, force, win, selection, range)
 	local files = module.nnn()
 	if files and files[1] ~= nil then
-		vis:command("e " .. files[1])
+		local file = table.remove(files, 1)
+		vis:command("e " .. file)
 	end
-	return true;
-end, "Select file to open with nnn")
+	for _, file in pairs(files) do
+		vis:command("open " .. file)
+	end
+end, "Select file(s) to open with nnn")
 
 return module

--- a/init.lua
+++ b/init.lua
@@ -7,7 +7,7 @@ module.nnn_args = ""
 
 vis:command_register("nnn", function(argv, force, win, selection, range)
 	local pickfile_name = os.tmpname()
-	local command = string.format(module.nnn_path .. " " .. module.nnn_args .. " -p %s", pickfile_name)
+	local command = module.nnn_path .. " " .. module.nnn_args .. " -p " .. pickfile_name
 	local status = vis:pipe(win.file, {start = 1, finish = 0}, command, true)
 	local pickfile = io.open(pickfile_name)
 	if not pickfile then
@@ -21,7 +21,7 @@ vis:command_register("nnn", function(argv, force, win, selection, range)
 	local success, msg, status = pickfile:close()
 	os.remove(pickfile_name)
 	if success and output[1] ~= nil then
-		vis:feedkeys(string.format(":e '%s'<Enter>", output[1]))
+		vis:feedkeys(":e " .. output[1] .. "<Enter>")
 	end
 	return true;
 end, "Select file to open with nnn")

--- a/init.lua
+++ b/init.lua
@@ -5,23 +5,30 @@ local module = {}
 module.nnn_path = "nnn"
 module.nnn_args = ""
 
-vis:command_register("nnn", function(argv, force, win, selection, range)
+module.nnn = function()
 	local pickfile_name = os.tmpname()
 	local command = module.nnn_path .. " " .. module.nnn_args .. " -p " .. pickfile_name
-	local status = vis:pipe(win.file, {start = 1, finish = 0}, command, true)
+	local status = vis:pipe(vis.win.file, {start = 1, finish = 0}, command, true)
 	local pickfile = io.open(pickfile_name)
 	if not pickfile then
 		vis:redraw()
-		return false
+		return
 	end
-	local output = {}
+	local files  = {}
 	for line in pickfile:lines() do
-		table.insert(output, line)
+		table.insert(files, line)
 	end
 	local success, msg, status = pickfile:close()
 	os.remove(pickfile_name)
-	if success and output[1] ~= nil then
-		vis:feedkeys(":e " .. output[1] .. "<Enter>")
+	if success then
+		return files
+	end
+end
+
+vis:command_register("nnn", function(argv, force, win, selection, range)
+	local files = module.nnn()
+	if files and files[1] ~= nil then
+		vis:command("e " .. files[1])
 	end
 	return true;
 end, "Select file to open with nnn")


### PR DESCRIPTION
Hi! Cool plugin! I think that one of the advantages of `nnn` over
`vis-menu` is that it allows you to select multiple files. To take
advantage of that I made the plugin open every file that was selected
instead of just the first. This does change the plugin to open a new
window even when only one file is selected though. If you are interested
in keeping that behaviour I can rework the patch to have two commands
`:ennn` and `:onnn` where `:ennn` will behave like the plugin currently
does.